### PR TITLE
add setsid to socat command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ export SSH_AUTH_SOCK=$HOME/.ssh/agent.sock
 ss -a | grep -q $SSH_AUTH_SOCK
 if [ $? -ne 0 ]; then
         rm -f $SSH_AUTH_SOCK
-        nohup socat UNIX-LISTEN:$SSH_AUTH_SOCK,fork EXEC:$HOME/.ssh/wsl2-ssh-pageant.exe >/dev/null 2>&1 &
+        setsid nohup socat UNIX-LISTEN:$SSH_AUTH_SOCK,fork EXEC:$HOME/.ssh/wsl2-ssh-pageant.exe >/dev/null 2>&1 &
 fi
 ```
 


### PR DESCRIPTION
I've got the problem that sometimes the background process gets killed by pressing ctrl+c. Adding `setsid` resolves this issues.