### PR TITLE
removed extra ;then in fish example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ fi
 ```
 set -x SSH_AUTH_SOCK $HOME/.ssh/agent.sock
 ss -a | grep -q $SSH_AUTH_SOCK
-if [ $status != 0 ]; then
+if [ $status != 0 ]
   rm -f $SSH_AUTH_SOCK
   setsid nohup socat UNIX-LISTEN:$SSH_AUTH_SOCK,fork EXEC:$HOME/.ssh/wsl2-ssh-pageant.exe >/dev/null 2>&1 &
 end
@@ -45,7 +45,7 @@ end
 ```
 set -x GPG_AGENT_SOCK $HOME/.gnupg/S.gpg-agent
 ss -a | grep -q $GPG_AGENT_SOCK
-if [ $status != 0 ]; then
+if [ $status != 0 ]
   rm -rf $GPG_AGENT_SOCK
   setsid nohup socat UNIX-LISTEN:$GPG_AGENT_SOCK,fork EXEC:"$HOME/.ssh/wsl2-ssh-pageant.exe --gpg S.gpg-agent" >/dev/null 2>&1 &
 end


### PR DESCRIPTION
This is invalid fish shell syntax (sorry my bad), I was comparing it to my own configuration I found that there's an extra `; then` coming from bash conversion.