### PR TITLE
README.md: Remove/replace existing sockets instead of skipping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ I use a Yubikey to store a GPG key pair and I like to use this key pair as my SS
 ```bash
 export SSH_AUTH_SOCK=$HOME/.ssh/agent.sock
 ss -a | grep -q $SSH_AUTH_SOCK
-if [ $? -ne 0 ]; then
+if [ $? -eq 0 ]; then
         rm -f $SSH_AUTH_SOCK
         (setsid nohup socat UNIX-LISTEN:$SSH_AUTH_SOCK,fork EXEC:$HOME/.ssh/wsl2-ssh-pageant.exe >/dev/null 2>&1 &)
 fi
@@ -24,7 +24,7 @@ fi
 ```bash
 export GPG_AGENT_SOCK=$HOME/.gnupg/S.gpg-agent
 ss -a | grep -q $GPG_AGENT_SOCK
-if [ $? -ne 0 ]; then
+if [ $? -eq 0 ]; then
         rm -rf $GPG_AGENT_SOCK
         (setsid nohup socat UNIX-LISTEN:$GPG_AGENT_SOCK,fork EXEC:"$HOME/.ssh/wsl2-ssh-pageant.exe --gpg S.gpg-agent" >/dev/null 2>&1 &)
 fi
@@ -36,7 +36,7 @@ fi
 ```fish
 set -x SSH_AUTH_SOCK $HOME/.ssh/agent.sock
 ss -a | grep -q $SSH_AUTH_SOCK
-if [ $status != 0 ]
+if [ $status == 0 ]
   rm -f $SSH_AUTH_SOCK
   setsid nohup socat UNIX-LISTEN:$SSH_AUTH_SOCK,fork EXEC:$HOME/.ssh/wsl2-ssh-pageant.exe >/dev/null 2>&1 &
 end
@@ -46,7 +46,7 @@ end
 ```fish
 set -x GPG_AGENT_SOCK $HOME/.gnupg/S.gpg-agent
 ss -a | grep -q $GPG_AGENT_SOCK
-if [ $status != 0 ]
+if [ $status == 0 ]
   rm -rf $GPG_AGENT_SOCK
   setsid nohup socat UNIX-LISTEN:$GPG_AGENT_SOCK,fork EXEC:"$HOME/.ssh/wsl2-ssh-pageant.exe --gpg S.gpg-agent" >/dev/null 2>&1 &
 end


### PR DESCRIPTION
Currently, if gpg-agent/ssh-agent have already started (which they seem to have in my wsl2), then this just exits immediately because grep returns 0, and doesn't re-map. I'm not sure if this was an attempt to prevent multiple wsl2-ssh-pageant.exe instances from clobbering each other, but it seems like given your first action is an rm -rf, it seems like this may just be a typo (grep returns 0 when it finds something).

In any case, this change is what got it to work on my machine, so it's possible there's just a corner case somewhere. Thanks!